### PR TITLE
Remove CURLOPT_USERAGENT to allow monitors to dynamically set user agent

### DIFF
--- a/src/RapidSpike/Utils/BasicCurl.php
+++ b/src/RapidSpike/Utils/BasicCurl.php
@@ -12,7 +12,7 @@ use RapidSpike\Targets\Url;
 class BasicCurl
 {
 
-    const BLOCKED_OPTIONS = [CURLOPT_SSL_VERIFYPEER, CURLOPT_RETURNTRANSFER, CURLOPT_USERAGENT];
+    const BLOCKED_OPTIONS = [CURLOPT_SSL_VERIFYPEER, CURLOPT_RETURNTRANSFER];
 
     /**
      * The URL object for the website we're interacting with


### PR DESCRIPTION
Remove CURLOPT_USERAGENT from BLOCKED_OPTIONS in BasicCurl 